### PR TITLE
fix: resolve naming mismatch between package and artifacts key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
         {
           packages.gel-server = mk_artifact {
             name = "gel-server";
-            url = artifacts.edgedb-server.${system};
+            url = artifacts.gel-server.${system};
           };
           packages.gel-server-nightly = mk_artifact {
             name = "gel-server";


### PR DESCRIPTION
This resolves the following error:

```
> nix build github:geldata/packages-nix#gel-server
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'gel-server'
         whose name attribute is located at /nix/store/j6vr7mnkldiga00c0zghh2frympmc0ca-source/pkgs/stdenv/generic/make-derivation.nix:438:13

       … while evaluating attribute 'src' of derivation 'gel-server'
         at /nix/store/r26gr7pj6x6r7l0jabzs1hn1p52hrm1s-source/flake.nix:40:15:
           39|               dontFixup = pkgs.stdenv.isDarwin;
           40|               src = pkgs.fetchurl url;
             |               ^
           41|               installPhase = ''

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'edgedb-server' missing
       at /nix/store/r26gr7pj6x6r7l0jabzs1hn1p52hrm1s-source/flake.nix:84:19:
           83|             name = "gel-server";
           84|             url = artifacts.edgedb-server.${system};
             |                   ^
           85|           };
```

With these changes:
```
> nix build github:armeenm/packages-nix/dev/fix-gel-server-package#gel-server
>
```